### PR TITLE
CategoryAPI を実装する

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -1,4 +1,5 @@
 export 'requests/categories/category_detail.dart';
+export 'requests/categories/category_records.dart';
 export 'requests/categories/category_variables.dart';
 
 export 'requests/games/game_categories.dart';

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -1,6 +1,4 @@
-export 'requests/series/series_list.dart';
-export 'requests/series/series_detail.dart';
-export 'requests/series/series_games.dart';
+export 'requests/categories/category_detail.dart';
 
 export 'requests/games/game_categories.dart';
 export 'requests/games/game_derived_games.dart';
@@ -9,3 +7,7 @@ export 'requests/games/game_levels.dart';
 export 'requests/games/game_list.dart';
 export 'requests/games/game_records.dart';
 export 'requests/games/game_variables.dart';
+
+export 'requests/series/series_detail.dart';
+export 'requests/series/series_games.dart';
+export 'requests/series/series_list.dart';

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -1,4 +1,5 @@
 export 'requests/categories/category_detail.dart';
+export 'requests/categories/category_variables.dart';
 
 export 'requests/games/game_categories.dart';
 export 'requests/games/game_derived_games.dart';

--- a/lib/src/requests/categories/category_detail.dart
+++ b/lib/src/requests/categories/category_detail.dart
@@ -1,0 +1,18 @@
+import 'package:http/http.dart' as http;
+
+import '../base_api.dart';
+import '../util/get_single_data.dart';
+import '../../models/category.dart';
+
+class CategoryDetailApi extends BaseApi with GetSingleData {
+  CategoryDetailApi({this.id});
+  String id;
+
+  @override
+  String endpointPath() => '/api/v1/categories/${id}';
+
+  @override
+  Map<String, dynamic> parseJsonData(http.Response response) {
+    return getSingleData(response, categoryFromJson);
+  }
+}

--- a/lib/src/requests/categories/category_records.dart
+++ b/lib/src/requests/categories/category_records.dart
@@ -1,0 +1,18 @@
+import 'package:http/http.dart' as http;
+
+import '../base_api.dart';
+import '../util/get_collection_data.dart';
+import '../../models/leaderboard.dart';
+
+class CategoryRecordsApi extends BaseApi with GetCollectionData {
+  CategoryRecordsApi({this.id});
+  String id;
+
+  @override
+  String endpointPath() => '/api/v1/categories/${id}/records';
+
+  @override
+  Map<String, dynamic> parseJsonData(http.Response response) {
+    return getCollectionData(response, leaderboardFromJson);
+  }
+}

--- a/lib/src/requests/categories/category_variables.dart
+++ b/lib/src/requests/categories/category_variables.dart
@@ -1,0 +1,18 @@
+import 'package:http/http.dart' as http;
+
+import '../base_api.dart';
+import '../util/get_collection_data.dart';
+import '../../models/variable.dart';
+
+class CategoryVariablesApi extends BaseApi with GetCollectionData {
+  CategoryVariablesApi({this.id});
+  String id;
+
+  @override
+  String endpointPath() => '/api/v1/categories/${id}/variables';
+
+  @override
+  Map<String, dynamic> parseJsonData(http.Response response) {
+    return getCollectionData(response, variableFromJson);
+  }
+}

--- a/test/requests/category/category_detail_test.dart
+++ b/test/requests/category/category_detail_test.dart
@@ -1,0 +1,38 @@
+import 'package:dart_speedrun_api/dart_speedrun_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Requests::Category::CategoryDetailApi', () {
+    CategoryDetailApi _api;
+
+    group('#request()', () {
+      group('valid', () {
+        test('Case default request', () async {
+          _api = CategoryDetailApi(id: 'nxd1rk8q');
+          var categoryDetail = await _api.request();
+
+          expect(categoryDetail['data'].runtimeType, Category);
+        });
+
+        test('Case with directUri member', () async {
+          var directUri = Uri.parse('https://www.speedrun.com/api/v1/categories/nxd1rk8q');
+          var _api = CategoryDetailApi();
+          var categoryDetail = await _api.request(directUri: directUri);
+
+          expect(categoryDetail['data'].runtimeType, Category);
+        });
+      });
+
+      group('invalid', () {
+        test('Case status 200, but null data', () async {
+          var directUri =
+              Uri.parse('https://www.speedrun.com/api/v1/categories/invalid');
+          var _api = CategoryDetailApi();
+          var categoryDetail = await _api.request(directUri: directUri);
+
+          expect(categoryDetail, null);
+        });
+      });
+    });
+  });
+}

--- a/test/requests/category/category_records_test.dart
+++ b/test/requests/category/category_records_test.dart
@@ -1,0 +1,38 @@
+import 'package:dart_speedrun_api/dart_speedrun_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Requests::Category::CategoryRecordsApi', () {
+    CategoryRecordsApi _api;
+
+    group('#request()', () {
+      group('valid', () {
+        test('Case default request', () async {
+          _api = CategoryRecordsApi(id: 'xd1m7rd8');
+          var categoryRecords = await _api.request();
+
+          expect(categoryRecords['data'].whereType<Leaderboard>().length, 1);
+        });
+
+        test('Case with directUri member', () async {
+          var directUri = Uri.parse('https://www.speedrun.com/api/v1/categories/xd1m7rd8/records');
+          var _api = CategoryRecordsApi();
+          var categoryRecords = await _api.request(directUri: directUri);
+
+          expect(categoryRecords['data'].whereType<Leaderboard>().length, 1);
+        });
+      });
+
+      group('invalid', () {
+        test('Case status 200, but null data', () async {
+          var directUri =
+              Uri.parse('https://www.speedrun.com/api/v1/categories/invalid');
+          var _api = CategoryRecordsApi();
+          var categoryRecords = await _api.request(directUri: directUri);
+
+          expect(categoryRecords, null);
+        });
+      });
+    });
+  });
+}

--- a/test/requests/category/category_variables_test.dart
+++ b/test/requests/category/category_variables_test.dart
@@ -1,0 +1,38 @@
+import 'package:dart_speedrun_api/dart_speedrun_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Requests::Category::CategoryVariablesApi', () {
+    CategoryVariablesApi _api;
+
+    group('#request()', () {
+      group('valid', () {
+        test('Case default request', () async {
+          _api = CategoryVariablesApi(id: 'xd1m7rd8');
+          var categoryVariables = await _api.request();
+
+          expect(categoryVariables['data'].whereType<Variable>().length, 2);
+        });
+
+        test('Case with directUri member', () async {
+          var directUri = Uri.parse('https://www.speedrun.com/api/v1/categories/xd1m7rd8/variables');
+          var _api = CategoryVariablesApi();
+          var categoryVariables = await _api.request(directUri: directUri);
+
+          expect(categoryVariables['data'].whereType<Variable>().length, 2);
+        });
+      });
+
+      group('invalid', () {
+        test('Case status 200, but null data', () async {
+          var directUri =
+              Uri.parse('https://www.speedrun.com/api/v1/categories/invalid');
+          var _api = CategoryVariablesApi();
+          var categoryVariables = await _api.request(directUri: directUri);
+
+          expect(categoryVariables, null);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
### なぜ
#2 

### やること

- [x] 実装
  - [x] Model 用意
  - [x] Endpoint を用意
    - GET /categories/{id}
    - GET /categories/{id}/variables
    - GET /categories/{id}/records
