### PR TITLE
[WIP]LeaderBoards の API を実装する

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -10,6 +10,8 @@ export 'requests/games/game_list.dart';
 export 'requests/games/game_records.dart';
 export 'requests/games/game_variables.dart';
 
+export 'requests/leaderboards/leaderboard_category.dart';
+
 export 'requests/series/series_detail.dart';
 export 'requests/series/series_games.dart';
 export 'requests/series/series_list.dart';

--- a/lib/src/requests/leaderboards/leaderboard_category.dart
+++ b/lib/src/requests/leaderboards/leaderboard_category.dart
@@ -1,0 +1,21 @@
+import 'package:http/http.dart' as http;
+
+import '../base_api.dart';
+import '../util/get_single_data.dart';
+import '../../models/leaderboard.dart';
+
+class LeaderboardCategoryApi extends BaseApi with GetSingleData {
+  LeaderboardCategoryApi({this.record_id, this.category_id})
+      : assert((record_id == null && category_id == null) || (record_id != null && category_id != null));
+  String record_id;
+  String category_id;
+
+  @override
+  String endpointPath() =>
+      '/api/v1/leaderboards/${record_id}/category/${category_id}';
+
+  @override
+  Map<String, dynamic> parseJsonData(http.Response response) {
+    return getSingleData(response, leaderboardFromJson);
+  }
+}

--- a/test/requests/leaderboards/leaderboard_category_test.dart
+++ b/test/requests/leaderboards/leaderboard_category_test.dart
@@ -3,9 +3,25 @@ import 'package:test/test.dart';
 
 void main() {
   group('Requests::Leaderboards::LeaderboardCategoryApi', () {
-    LeaderboardCategoryApi _api;
+    group('Constructor', () {
+      group('invalid', () {
+        test('Case only record_id', () {
+          expect(() {
+            LeaderboardCategoryApi(record_id: 'pdvzq96w');
+          }, throwsA(isA<AssertionError>()));
+        });
+
+        test('Case only category_id', () {
+          expect(() {
+            LeaderboardCategoryApi(category_id: 'z276ozd0');
+          }, throwsA(isA<AssertionError>()));
+        });
+      });
+    });
 
     group('#request()', () {
+      LeaderboardCategoryApi _api;
+
       group('valid', () {
         test('Case default request', () async {
           _api = LeaderboardCategoryApi(
@@ -33,18 +49,6 @@ void main() {
           var leaderboardCategory = await _api.request(directUri: directUri);
 
           expect(leaderboardCategory, null);
-        });
-
-        test('Case only record_id', () {
-          expect(() {
-            LeaderboardCategoryApi(record_id: 'pdvzq96w');
-          }, throwsA(isA<AssertionError>()));
-        });
-
-        test('Case only category_id', () {
-          expect(() {
-            LeaderboardCategoryApi(category_id: 'z276ozd0');
-          }, throwsA(isA<AssertionError>()));
         });
       });
     });

--- a/test/requests/leaderboards/leaderboard_category_test.dart
+++ b/test/requests/leaderboards/leaderboard_category_test.dart
@@ -1,0 +1,52 @@
+import 'package:dart_speedrun_api/dart_speedrun_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Requests::Leaderboards::LeaderboardCategoryApi', () {
+    LeaderboardCategoryApi _api;
+
+    group('#request()', () {
+      group('valid', () {
+        test('Case default request', () async {
+          _api = LeaderboardCategoryApi(
+              record_id: 'pdvzq96w', category_id: 'z276ozd0');
+          var leaderboardCategory = await _api.request();
+
+          expect(leaderboardCategory['data'].runtimeType, Leaderboard);
+        });
+
+        test('Case with directUri member', () async {
+          var directUri = Uri.parse(
+              'https://www.speedrun.com/api/v1/leaderboards/pdvzq96w/category/z276ozd0');
+          var _api = LeaderboardCategoryApi();
+          var leaderboardCategory = await _api.request(directUri: directUri);
+
+          expect(leaderboardCategory['data'].runtimeType, Leaderboard);
+        });
+      });
+
+      group('invalid', () {
+        test('Case status 200, but null data', () async {
+          var directUri = Uri.parse(
+              'https://www.speedrun.com/api/v1/leaderboards/invalid/category/invalid');
+          var _api = LeaderboardCategoryApi();
+          var leaderboardCategory = await _api.request(directUri: directUri);
+
+          expect(leaderboardCategory, null);
+        });
+
+        test('Case only record_id', () {
+          expect(() {
+            LeaderboardCategoryApi(record_id: 'pdvzq96w');
+          }, throwsA(isA<AssertionError>()));
+        });
+
+        test('Case only category_id', () {
+          expect(() {
+            LeaderboardCategoryApi(category_id: 'z276ozd0');
+          }, throwsA(isA<AssertionError>()));
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
- fixed #5 


## 実装
- [ ] 実装
  - [x] Model 用意
  - [ ] Endpoint を用意
    - [x] GET /leaderboards/{game}/category/{category}
    - [ ] GET /leaderboards/{game}/level/{level}/{category}
